### PR TITLE
fix: replace recursive Mono chains with iterative expand to prevent S…

### DIFF
--- a/src/main/java/it/pagopa/pn/delayer/middleware/dao/dynamo/PaperDeliveryDAOImpl.java
+++ b/src/main/java/it/pagopa/pn/delayer/middleware/dao/dynamo/PaperDeliveryDAOImpl.java
@@ -58,11 +58,13 @@ public class PaperDeliveryDAOImpl implements PaperDeliveryDAO {
     public Mono<Void> insertPaperDeliveries(List<PaperDelivery> paperDeliveries) {
         if(!CollectionUtils.isEmpty(paperDeliveries)) {
             return Flux.fromIterable(paperDeliveries).buffer(25)
-                    .flatMap(chunk -> insertWithRetry(chunk, 10))
+                    .flatMap(chunk -> insertWithRetry(chunk, MAX_BATCH_WRITE_RETRIES))
                     .then();
         }
         return Mono.empty();
     }
+
+    private static final int MAX_BATCH_WRITE_RETRIES = 10;
 
     private Mono<Void> insertWithRetry(List<PaperDelivery> paperDeliveriesChunk, int retriesLeft) {
         BatchWriteItemEnhancedRequest.Builder batchBuilder = BatchWriteItemEnhancedRequest.builder();
@@ -80,10 +82,10 @@ public class PaperDeliveryDAOImpl implements PaperDeliveryDAO {
                 if (unprocessed != null && !unprocessed.isEmpty()) {
                     if (retriesLeft > 1) {
                         log.info("Retrying batch write for {} unprocessed items, {} retries left", unprocessed.size(), retriesLeft - 1);
-                        return Mono.delay(Duration.ofSeconds(3)).then(insertWithRetry(unprocessed, retriesLeft - 1));
+                        return Mono.delay(Duration.ofSeconds(3)).then(Mono.defer(() -> insertWithRetry(unprocessed, retriesLeft - 1)));
                     } else {
-                        log.error("Failed to insert PaperDelivery after 3 attempts, unprocessed items remain: {}", unprocessed);
-                        return Mono.error(new PnInternalException("Error during insert PaperDelivery, Unprocessed items remain after 3 attempts", ERROR_CODE_INSERT_PAPER_DELIVERY_ENTITY));
+                        log.error("Failed to insert PaperDelivery after {} attempts, unprocessed items remain: {}", MAX_BATCH_WRITE_RETRIES, unprocessed);
+                        return Mono.error(new PnInternalException("Error during insert PaperDelivery, Unprocessed items remain after " + MAX_BATCH_WRITE_RETRIES + " attempts", ERROR_CODE_INSERT_PAPER_DELIVERY_ENTITY));
                     }
                 }
                 return Mono.empty();

--- a/src/main/java/it/pagopa/pn/delayer/utils/PaperDeliveryUtils.java
+++ b/src/main/java/it/pagopa/pn/delayer/utils/PaperDeliveryUtils.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
@@ -68,10 +69,15 @@ public class PaperDeliveryUtils {
     }
 
     private Mono<Void> sendToNextWeek(WorkflowStepEnum workflowStepEnum, String sortKeyPrefix, Map<String, AttributeValue> lastEvaluatedKey, LocalDate deliveryWeek) {
-        return retrievePaperDeliveries(workflowStepEnum, deliveryWeek, sortKeyPrefix, lastEvaluatedKey, pnDelayerConfigs.getDao().getPaperDeliveryQueryLimit())
-                .flatMap(paperDeliveryPage -> processChunkToSendToNextWeek(paperDeliveryPage.items(), deliveryWeek)
-                        .flatMap(unused -> !CollectionUtils.isEmpty(paperDeliveryPage.lastEvaluatedKey()) ?
-                                sendToNextWeek(workflowStepEnum, sortKeyPrefix, paperDeliveryPage.lastEvaluatedKey(), deliveryWeek) : Mono.empty()));
+        return Mono.just(lastEvaluatedKey)
+                .expand(currentKey ->
+                        retrievePaperDeliveries(workflowStepEnum, deliveryWeek, sortKeyPrefix, currentKey, pnDelayerConfigs.getDao().getPaperDeliveryQueryLimit())
+                                .flatMap(page -> processChunkToSendToNextWeek(page.items(), deliveryWeek)
+                                        .then(CollectionUtils.isEmpty(page.lastEvaluatedKey())
+                                                ? Mono.<Map<String, AttributeValue>>empty()
+                                                : Mono.just(page.lastEvaluatedKey())))
+                )
+                .then();
     }
 
 
@@ -101,9 +107,9 @@ public class PaperDeliveryUtils {
      * @param deliveryWeek     the week for which the deliveries are processed
      * @param residualCapacity the remaining capacity for processing deliveries
      * @param declaredCapacity the declared capacity for the province
-     * @return a Mono containing the number of deliveries sent to the next step
+     * @return a Mono that completes when all deliveries have been processed
      */
-    private Mono<Integer> sendToNextStep(WorkflowStepEnum workflowStepEnum,
+    private Mono<Void> sendToNextStep(WorkflowStepEnum workflowStepEnum,
                                          String sortKeyPrefix,
                                          Map<String, AttributeValue> lastEvaluatedKey,
                                          String tenderId,
@@ -119,27 +125,53 @@ public class PaperDeliveryUtils {
         String unifiedDeliveryDriver = splittedSortKeyPrefix[0];
         String province = splittedSortKeyPrefix[1];
 
-        return retrievePaperDeliveries(workflowStepEnum, deliveryWeek, sortKeyPrefix, lastEvaluatedKey, Math.min(residualCapacity, pnDelayerConfigs.getDao().getPaperDeliveryQueryLimit()))
-                .flatMap(paperDeliveryPage -> processChunkToSendToNextStep(paperDeliveryPage.items(), unifiedDeliveryDriver, tenderId, deliveryWeek, printCounter, driverCapacityJobProcessResult)
-                        .flatMap(processResult -> {
-                            log.info("driverCapacityJobProcessResult for province={} and unifiedDeliveryDriver={} after processing chunk: sentToNextStep={}, totalIncrements={}",
-                                    province, unifiedDeliveryDriver, processResult.getSentToNextStep(), processResult.getIncrementUsedCapacityDtos().size());
-                            int residualCapacityAfterSending = declaredCapacity - (usedCapacityBase + processResult.getSentToNextStep());
-                            if (!CollectionUtils.isEmpty(paperDeliveryPage.lastEvaluatedKey()) && residualCapacityAfterSending > 0) {
-                                log.info("Continuing to process chunk to send to next step for province={} and unifiedDeliveryDriver={}, residualCapacityAfterSending={}", province, unifiedDeliveryDriver, residualCapacityAfterSending);
-                                return sendToNextStep(workflowStepEnum, sortKeyPrefix, paperDeliveryPage.lastEvaluatedKey(), tenderId, deliveryWeek, residualCapacityAfterSending, declaredCapacity, weeklyPrintCapacity, printCounter, processResult, usedCapacityBase)
-                                        .thenReturn(residualCapacityAfterSending);
-                            } else {
-                                log.info("Finished processing chunk to send to next step for province={} and unifiedDeliveryDriver={}, residualCapacityAfterSending={}", province, unifiedDeliveryDriver, residualCapacityAfterSending);
-                                processResult.getIncrementUsedCapacityDtos().add(new IncrementUsedCapacityDto(unifiedDeliveryDriver, province, processResult.getSentToNextStep(), deliveryWeek, declaredCapacity));
-                                return flushCounters(deliveryWeek, weeklyPrintCapacity, printCounter, driverCapacityJobProcessResult.getIncrementUsedCapacityDtos())
-                                        .thenReturn(residualCapacityAfterSending);
-                            }
-                        })
-                        .filter(residualCapacityAfterSending -> residualCapacityAfterSending <= 0 && !CollectionUtils.isEmpty(paperDeliveryPage.lastEvaluatedKey()))
-                        .doOnNext(residualCapacityAfterSending -> log.info("Process next chunk to send to next week for province={} and unifiedDeliveryDriver={}, residualCapacityAfterSending={}", province, unifiedDeliveryDriver, residualCapacityAfterSending))
-                        .flatMap(unused -> sendToNextWeek(workflowStepEnum, sortKeyPrefix, paperDeliveryPage.lastEvaluatedKey(), deliveryWeek))
-                        .thenReturn(paperDeliveryPage.items().size()));
+        AtomicBoolean anyPageProcessed = new AtomicBoolean(false);
+
+        return Mono.just(new SendToNextStepIterState(lastEvaluatedKey, residualCapacity, true))
+                .expand(state -> {
+                    if (!state.hasMorePages() || state.residualCapacity() <= 0) {
+                        return Mono.empty();
+                    }
+                    return retrievePaperDeliveries(workflowStepEnum, deliveryWeek, sortKeyPrefix, state.lastEvaluatedKey(), Math.min(state.residualCapacity(), pnDelayerConfigs.getDao().getPaperDeliveryQueryLimit()))
+                            .flatMap(paperDeliveryPage -> {
+                                anyPageProcessed.set(true);
+                                return processChunkToSendToNextStep(paperDeliveryPage.items(), unifiedDeliveryDriver, tenderId, deliveryWeek, printCounter, driverCapacityJobProcessResult)
+                                        .map(processResult -> {
+                                            int residualCapacityAfterSending = declaredCapacity - (usedCapacityBase + processResult.getSentToNextStep());
+                                            boolean hasMore = !CollectionUtils.isEmpty(paperDeliveryPage.lastEvaluatedKey());
+                                            log.info("driverCapacityJobProcessResult for province={} and unifiedDeliveryDriver={} after processing chunk: sentToNextStep={}, totalIncrements={}",
+                                                    province, unifiedDeliveryDriver, processResult.getSentToNextStep(), processResult.getIncrementUsedCapacityDtos().size());
+                                            if (hasMore && residualCapacityAfterSending > 0) {
+                                                log.info("Continuing to process chunk to send to next step for province={} and unifiedDeliveryDriver={}, residualCapacityAfterSending={}", province, unifiedDeliveryDriver, residualCapacityAfterSending);
+                                            } else {
+                                                log.info("Finished processing chunk to send to next step for province={} and unifiedDeliveryDriver={}, residualCapacityAfterSending={}", province, unifiedDeliveryDriver, residualCapacityAfterSending);
+                                            }
+                                            return new SendToNextStepIterState(
+                                                    hasMore ? paperDeliveryPage.lastEvaluatedKey() : null,
+                                                    residualCapacityAfterSending,
+                                                    hasMore
+                                            );
+                                        });
+                            });
+                })
+                .last()
+                .flatMap(finalState -> {
+                    if (!anyPageProcessed.get()) {
+                        return Mono.<Void>empty();
+                    }
+                    driverCapacityJobProcessResult.getIncrementUsedCapacityDtos().add(
+                            new IncrementUsedCapacityDto(unifiedDeliveryDriver, province,
+                                    driverCapacityJobProcessResult.getSentToNextStep(), deliveryWeek, declaredCapacity));
+                    return flushCounters(deliveryWeek, weeklyPrintCapacity, printCounter, driverCapacityJobProcessResult.getIncrementUsedCapacityDtos())
+                            .then(
+                                    finalState.residualCapacity() <= 0 && finalState.hasMorePages()
+                                            ? Mono.defer(() -> {
+                                                log.info("Process next chunk to send to next week for province={} and unifiedDeliveryDriver={}, residualCapacityAfterSending={}", province, unifiedDeliveryDriver, finalState.residualCapacity());
+                                                return sendToNextWeek(workflowStepEnum, sortKeyPrefix, finalState.lastEvaluatedKey(), deliveryWeek);
+                                            })
+                                            : Mono.<Void>empty()
+                            );
+                });
     }
 
     private Mono<Void> flushCounters(LocalDate deliveryWeek,
@@ -246,4 +278,10 @@ public class PaperDeliveryUtils {
                         .thenReturn(senderLimitJobProcessObjects.getSendToDriverCapacityStep())
                         .doOnNext(paperDeliveries -> paperDeliveries.removeIf(paperDelivery -> paperDelivery.getProductType().equalsIgnoreCase("RS") || paperDelivery.getAttempt() == 1)));
     }
+
+    private record SendToNextStepIterState(
+            Map<String, AttributeValue> lastEvaluatedKey,
+            int residualCapacity,
+            boolean hasMorePages
+    ) {}
 }

--- a/src/test/java/it/pagopa/pn/delayer/utils/PaperDeliveryUtilsTest.java
+++ b/src/test/java/it/pagopa/pn/delayer/utils/PaperDeliveryUtilsTest.java
@@ -9,6 +9,7 @@ import it.pagopa.pn.delayer.model.WorkflowStepEnum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
@@ -18,11 +19,11 @@ import reactor.util.function.Tuples;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+import java.time.Duration;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import static it.pagopa.pn.delayer.model.WorkflowStepEnum.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -46,6 +47,10 @@ public class PaperDeliveryUtilsTest {
         PnDelayerConfigs.Dao daoConfig = new PnDelayerConfigs.Dao();
         daoConfig.setPaperDeliveryQueryLimit(10);
         config.setDao(daoConfig);
+        config.setPrintCapacityWeeklyWorkingDays(7);
+        config.setPrintCapacity(List.of("1970-01-01;180000"));
+        config.setPrintCounterTtlDuration(Duration.ofDays(7));
+        config.setDeliveryDateDayOfWeek(1);
         paperDeliveryUtils = new PaperDeliveryUtils(paperDeliveryDAO, config, new PnDelayerUtils(config, new PrintCapacityUtils(config)), deliveryDriverUtils, paperDeliveryCounterDAO);
     }
 
@@ -128,6 +133,180 @@ public class PaperDeliveryUtilsTest {
         paperDeliveryUtils.insertPaperDeliveries(new SenderLimitJobProcessObjects(), deliveryWeek).block();
 
         verify(paperDeliveryDAO,times(2)).insertPaperDeliveries(anyList());
+    }
+
+    @Test
+    void evaluateCapacitiesNoCapacity_sendToNextWeek_multiPage() {
+        // Province capacity exhausted → all items go to next week via sendToNextWeek.
+        // DynamoDB returns 3 pages: page1 → page2 → page3 (last page, no lastEvaluatedKey).
+        String unifiedDeliveryDriver = "driver1";
+        String province = "RM";
+        LocalDate deliveryWeek = LocalDate.parse("2025-01-06");
+        String tenderId = "tender1";
+
+        // Province capacity = 0 → triggers sendToNextWeek path
+        when(deliveryDriverUtils.retrieveDeclaredAndUsedCapacity(eq(province), any(), any(), any()))
+                .thenReturn(Mono.just(Tuples.of(10, 10)));
+
+        // Build 3 pages with lastEvaluatedKey chaining
+        Map<String, AttributeValue> key1 = Map.of("pk", AttributeValue.builder().s("k1").build());
+        Map<String, AttributeValue> key2 = Map.of("pk", AttributeValue.builder().s("k2").build());
+
+        Page<PaperDelivery> page1 = mock(Page.class);
+        when(page1.items()).thenReturn(List.of(
+                createPaperDelivery("AR", "00179", province, "sender1", 1),
+                createPaperDelivery("AR", "00178", province, "sender2", 1)));
+        when(page1.lastEvaluatedKey()).thenReturn(key1);
+
+        Page<PaperDelivery> page2 = mock(Page.class);
+        when(page2.items()).thenReturn(List.of(
+                createPaperDelivery("RS", "00180", province, "sender3", 0)));
+        when(page2.lastEvaluatedKey()).thenReturn(key2);
+
+        // Last page — empty lastEvaluatedKey signals end of pagination
+        Page<PaperDelivery> page3 = mock(Page.class);
+        when(page3.items()).thenReturn(List.of(
+                createPaperDelivery("AR", "00181", province, "sender4", 1)));
+        when(page3.lastEvaluatedKey()).thenReturn(Collections.emptyMap());
+
+        when(paperDeliveryDAO.retrievePaperDeliveries(
+                eq(EVALUATE_DRIVER_CAPACITY), any(),
+                eq(String.join("~", unifiedDeliveryDriver, province)),
+                argThat(map -> map != null && map.isEmpty()), eq(10)))
+                .thenReturn(Mono.just(page1));
+
+        when(paperDeliveryDAO.retrievePaperDeliveries(
+                eq(EVALUATE_DRIVER_CAPACITY), any(),
+                eq(String.join("~", unifiedDeliveryDriver, province)),
+                eq(key1), eq(10)))
+                .thenReturn(Mono.just(page2));
+
+        when(paperDeliveryDAO.retrievePaperDeliveries(
+                eq(EVALUATE_DRIVER_CAPACITY), any(),
+                eq(String.join("~", unifiedDeliveryDriver, province)),
+                eq(key2), eq(10)))
+                .thenReturn(Mono.just(page3));
+
+        when(paperDeliveryDAO.insertPaperDeliveries(anyList()))
+                .thenReturn(Mono.empty());
+
+        StepVerifier.create(paperDeliveryUtils.evaluateCapacitiesAndProcessDeliveries(
+                        WorkflowStepEnum.EVALUATE_DRIVER_CAPACITY, unifiedDeliveryDriver, province, deliveryWeek, tenderId))
+                .verifyComplete();
+
+        // retrievePaperDeliveries called 3 times (one per page)
+        verify(paperDeliveryDAO, times(3)).retrievePaperDeliveries(
+                eq(EVALUATE_DRIVER_CAPACITY), any(),
+                eq(String.join("~", unifiedDeliveryDriver, province)),
+                any(), eq(10));
+
+        // insertPaperDeliveries called 3 times (one insert per page chunk)
+        verify(paperDeliveryDAO, times(3)).insertPaperDeliveries(anyList());
+    }
+
+    @Test
+    void evaluateCapacitiesWithCapacity_sendToNextStep_multiPage() {
+        // Province has capacity → items go through sendToNextStep with multi-page pagination.
+        // After capacity is consumed, remaining items go to next week.
+        String unifiedDeliveryDriver = "driver1";
+        String province = "RM";
+        LocalDate deliveryWeek = LocalDate.parse("2025-01-06");
+        String tenderId = "tender1";
+
+        // Province: declared=3, used=0 → residual=3
+        when(deliveryDriverUtils.retrieveDeclaredAndUsedCapacity(eq(province), any(), any(), any()))
+                .thenReturn(Mono.just(Tuples.of(3, 0)));
+
+        // CAP capacity: enough for all items
+        when(deliveryDriverUtils.retrieveDeclaredAndUsedCapacity(eq("00184"), any(), any(), any()))
+                .thenReturn(Mono.just(Tuples.of(5, 0)))
+                .thenReturn(Mono.just(Tuples.of(5, 0)));
+        when(deliveryDriverUtils.retrieveDeclaredAndUsedCapacity(eq("00185"), any(), any(), any()))
+                .thenReturn(Mono.just(Tuples.of(1, 1)));
+
+        // Page 1: 2 items, has more pages
+        Map<String, AttributeValue> key1 = Map.of("pk", AttributeValue.builder().s("k1").build());
+        Page<PaperDelivery> page1 = mock(Page.class);
+        PaperDelivery d1 = createPaperDelivery("AR", "00185", province, "sender1", 0);
+        d1.setPk("2025-01-06~" + EVALUATE_DRIVER_CAPACITY);
+        d1.setSk("driver1~RM~2025-01-02T00:00:00Z~req1");
+        d1.setPrepareRequestDate("2025-01-02T00:00:00Z");
+        d1.setCreatedAt("2025-01-01T00:00:00Z");
+        PaperDelivery d2 = createPaperDelivery("AR", "00184", province, "sender2", 0);
+        d2.setPk("2025-01-06~" + EVALUATE_DRIVER_CAPACITY);
+        d2.setSk("driver1~RM~2025-01-01T00:00:00Z~req2");
+        d2.setPrepareRequestDate("2025-01-02T00:00:00Z");
+        d2.setCreatedAt("2025-01-01T00:00:00Z");
+        when(page1.items()).thenReturn(List.of(d1, d2));
+        when(page1.lastEvaluatedKey()).thenReturn(key1);
+
+        // Page 2: 2 more items, has more pages
+        Map<String, AttributeValue> key2 = Map.of("pk", AttributeValue.builder().s("k2").build());
+        Page<PaperDelivery> page2 = mock(Page.class);
+        PaperDelivery d3 = createPaperDelivery("AR", "00184", province, "sender3", 0);
+        d3.setPk("2025-01-06~" + EVALUATE_DRIVER_CAPACITY);
+        d3.setSk("driver1~RM~2025-01-01T00:00:00Z~req3");
+        d3.setPrepareRequestDate("2025-01-02T00:00:00Z");
+        d3.setCreatedAt("2025-01-01T00:00:00Z");
+        PaperDelivery d4 = createPaperDelivery("AR", "00184", province, "sender4", 0);
+        d4.setPk("2025-01-06~" + EVALUATE_DRIVER_CAPACITY);
+        d4.setSk("driver1~RM~2025-01-01T00:00:00Z~req4");
+        d4.setPrepareRequestDate("2025-01-02T00:00:00Z");
+        d4.setCreatedAt("2025-01-01T00:00:00Z");
+        when(page2.items()).thenReturn(List.of(d3, d4));
+        when(page2.lastEvaluatedKey()).thenReturn(key2);
+
+        // Remaining page for sendToNextWeek (after capacity exhausted)
+        Page<PaperDelivery> lastPage = mock(Page.class);
+        PaperDelivery d5 = createPaperDelivery("AR", "00184", province, "sender5", 0);
+        d5.setPk("2025-01-06~" + EVALUATE_DRIVER_CAPACITY);
+        d5.setSk("driver1~RM~2025-01-01T00:00:00Z~req5");
+        d5.setPrepareRequestDate("2025-01-02T00:00:00Z");
+        d5.setCreatedAt("2025-01-01T00:00:00Z");
+        when(lastPage.items()).thenReturn(List.of(d5));
+        when(lastPage.lastEvaluatedKey()).thenReturn(Collections.emptyMap());
+
+        // Page 1 returned for queryLimit=min(3,10)=3
+        when(paperDeliveryDAO.retrievePaperDeliveries(
+                eq(EVALUATE_DRIVER_CAPACITY), any(),
+                eq(String.join("~", unifiedDeliveryDriver, province)),
+                argThat(map -> map != null && map.isEmpty()), eq(3)))
+                .thenReturn(Mono.just(page1));
+
+        // Page 2 returned for queryLimit=min(2,10)=2 (residual shrinks after page1)
+        when(paperDeliveryDAO.retrievePaperDeliveries(
+                eq(EVALUATE_DRIVER_CAPACITY), any(),
+                eq(String.join("~", unifiedDeliveryDriver, province)),
+                eq(key1), anyInt()))
+                .thenReturn(Mono.just(page2));
+
+        // Last page for sendToNextWeek
+        when(paperDeliveryDAO.retrievePaperDeliveries(
+                eq(EVALUATE_DRIVER_CAPACITY), any(),
+                eq(String.join("~", unifiedDeliveryDriver, province)),
+                eq(key2), eq(10)))
+                .thenReturn(Mono.just(lastPage));
+
+        ArgumentCaptor<List<PaperDelivery>> insertCaptor = ArgumentCaptor.forClass(List.class);
+        when(paperDeliveryDAO.insertPaperDeliveries(insertCaptor.capture())).thenReturn(Mono.empty());
+        when(paperDeliveryCounterDAO.updatePrintCapacityCounter(any(), anyInt(), anyInt())).thenReturn(Mono.empty());
+        when(deliveryDriverUtils.updateCounters(anyList())).thenReturn(Mono.empty());
+
+        StepVerifier.create(paperDeliveryUtils.evaluateCapacitiesAndProcessDeliveries(
+                        WorkflowStepEnum.EVALUATE_DRIVER_CAPACITY, unifiedDeliveryDriver, province, deliveryWeek, tenderId))
+                .verifyComplete();
+
+        // At least 2 retrievePaperDeliveries calls for sendToNextStep pagination + 1 for sendToNextWeek
+        verify(paperDeliveryDAO, atLeast(2)).retrievePaperDeliveries(
+                eq(EVALUATE_DRIVER_CAPACITY), any(),
+                eq(String.join("~", unifiedDeliveryDriver, province)),
+                any(), anyInt());
+
+        // insertPaperDeliveries called multiple times (chunks from nextStep + nextWeek)
+        verify(paperDeliveryDAO, atLeast(2)).insertPaperDeliveries(anyList());
+
+        // Counters flushed exactly once
+        verify(deliveryDriverUtils, times(1)).updateCounters(anyList());
     }
 
     private PaperDelivery createPaperDelivery(String productType, String cap, String province, String senderPaId, Integer attempt) {


### PR DESCRIPTION
…tackOverflowError

Replace recursive flatMap pagination in sendToNextWeek and sendToNextStep with Mono.expand() which uses constant stack depth. Wrap insertWithRetry recursive call in Mono.defer() for lazy assembly.