### PR TITLE
[PN-20082] - Added excludeEmptyPaId method to add empty paId record to residual capacity step

### DIFF
--- a/src/main/java/it/pagopa/pn/delayer/service/EvaluateSenderLimitJobServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/delayer/service/EvaluateSenderLimitJobServiceImpl.java
@@ -113,6 +113,7 @@ public class EvaluateSenderLimitJobServiceImpl implements EvaluateSenderLimitJob
      */
     private Mono<SenderLimitJobProcessObjects> processItems(List<PaperDelivery> items, String tenderId, LocalDate deliveryWeek, List<DriversTotalCapacity> driversTotalCapacity, SenderLimitJobProcessObjects senderLimitJobProcessObjects) {
         return retrieveUnifiedDeliveryDriverAndAssignToPaperDeliveries(items, tenderId, driversTotalCapacity, senderLimitJobProcessObjects.getPriorityMap())
+                .map(paperDeliveries -> pnDelayerUtils.excludeEmptyPaId(paperDeliveries, senderLimitJobProcessObjects))
                 .map(paperDeliveryList -> pnDelayerUtils.excludeRsAndSecondAttempt(paperDeliveryList, senderLimitJobProcessObjects))
                 .map(pnDelayerUtils::groupByPaIdProductTypeProvince)
                 .flatMap(deliveriesGroupedByProductTypePaId -> senderLimitUtils.retrieveAndEvaluateSenderLimit(deliveryWeek, deliveriesGroupedByProductTypePaId, driversTotalCapacity, senderLimitJobProcessObjects))

--- a/src/main/java/it/pagopa/pn/delayer/service/EvaluateSenderLimitJobServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/delayer/service/EvaluateSenderLimitJobServiceImpl.java
@@ -113,9 +113,7 @@ public class EvaluateSenderLimitJobServiceImpl implements EvaluateSenderLimitJob
      */
     private Mono<SenderLimitJobProcessObjects> processItems(List<PaperDelivery> items, String tenderId, LocalDate deliveryWeek, List<DriversTotalCapacity> driversTotalCapacity, SenderLimitJobProcessObjects senderLimitJobProcessObjects) {
         return retrieveUnifiedDeliveryDriverAndAssignToPaperDeliveries(items, tenderId, driversTotalCapacity, senderLimitJobProcessObjects.getPriorityMap())
-                .map(paperDeliveries -> pnDelayerUtils.excludeEmptyPaId(paperDeliveries, senderLimitJobProcessObjects))
-                .map(paperDeliveryList -> pnDelayerUtils.excludeRsAndSecondAttempt(paperDeliveryList, senderLimitJobProcessObjects))
-                .map(pnDelayerUtils::groupByPaIdProductTypeProvince)
+                .map(paperDeliveries -> pnDelayerUtils.classifyAndGroupForSenderLimit(paperDeliveries, senderLimitJobProcessObjects))
                 .flatMap(deliveriesGroupedByProductTypePaId -> senderLimitUtils.retrieveAndEvaluateSenderLimit(deliveryWeek, deliveriesGroupedByProductTypePaId, driversTotalCapacity, senderLimitJobProcessObjects))
                 .flatMap(deliveries -> paperDeliveryUtils.insertPaperDeliveries(deliveries, deliveryWeek))
                 .filter(sentToNextStep -> !CollectionUtils.isEmpty(sentToNextStep))

--- a/src/main/java/it/pagopa/pn/delayer/utils/PnDelayerUtils.java
+++ b/src/main/java/it/pagopa/pn/delayer/utils/PnDelayerUtils.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
+import org.springframework.util.StringUtils;
 
 import java.time.DayOfWeek;
 import java.time.Instant;
@@ -170,11 +171,23 @@ public class PnDelayerUtils {
         var legalItems = partitionedByCommType.get(false);
         var byRsOrSecondAttempt = legalItems.stream().collect(Collectors.partitioningBy(this::isRsOrSecondAttempt));
         senderLimitJobProcessObjects.setSendToDriverCapacityStep(byRsOrSecondAttempt.get(true));
-        senderLimitJobProcessObjects.setSendToResidualCapacityStep(
-                new ArrayList<>(informalItems)
-        );
+        senderLimitJobProcessObjects.getSendToResidualCapacityStep().addAll(informalItems);
 
         return new ArrayList<>(byRsOrSecondAttempt.get(false));
+    }
+
+    public List<PaperDelivery> excludeEmptyPaId(List<PaperDelivery> paperDeliveries, SenderLimitJobProcessObjects senderLimitJobProcessObjects) {
+        var partitioned = paperDeliveries.stream()
+                .collect(Collectors.partitioningBy(paperDelivery -> StringUtils.hasText(paperDelivery.getSenderPaId())));
+
+        var paperDeliveriesWithPaId = partitioned.get(true);
+        var paperDeliveriesWithoutPaId = partitioned.get(false);
+
+        senderLimitJobProcessObjects.setSendToResidualCapacityStep(
+                new ArrayList<>(paperDeliveriesWithoutPaId)
+        );
+
+        return new ArrayList<>(paperDeliveriesWithPaId);
     }
 
     private boolean isInformal(PaperDelivery paperDelivery) {

--- a/src/main/java/it/pagopa/pn/delayer/utils/PnDelayerUtils.java
+++ b/src/main/java/it/pagopa/pn/delayer/utils/PnDelayerUtils.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -39,19 +40,6 @@ public class PnDelayerUtils {
         return paperDeliveries.stream().collect(Collectors.groupingBy(PaperDelivery::getCap, Collectors.toList()));
     }
 
-    public Map<String, List<PaperDelivery>> groupByPaIdProductTypeProvince(List<PaperDelivery> paperDeliveries) {
-        return paperDeliveries.stream()
-                .collect(Collectors.groupingBy(paperDelivery -> paperDelivery.getSenderPaId() + "~" + paperDelivery.getProductType() + "~" + paperDelivery.getProvince(),
-                        Collectors.toList()));
-    }
-
-    public Map<String, Long> groupByPaIdProductTypeProvinceAndCount(List<PaperDelivery> paperDeliveries) {
-        return paperDeliveries.stream()
-                .collect(Collectors.groupingBy(
-                        paperDelivery -> paperDelivery.getSenderPaId() + "~" + paperDelivery.getProductType() + "~" + paperDelivery.getProvince(),
-                        Collectors.counting()));
-    }
-
     public Map<String, String> groupByGeoKeyAndProduct(List<PaperChannelDeliveryDriver> paperChannelDeliveryDriver) {
         return paperChannelDeliveryDriver.stream()
                 .collect(Collectors.toMap(item -> item.getGeoKey() + "~" + item.getProduct(), PaperChannelDeliveryDriver::getUnifiedDeliveryDriver, (x, y) -> x));
@@ -59,6 +47,61 @@ public class PnDelayerUtils {
 
     public Map<String, List<PaperDelivery>> groupByCapAndProductType(List<PaperDelivery> paperDeliveries) {
         return paperDeliveries.stream().collect(Collectors.groupingBy(paperDelivery -> paperDelivery.getCap() + "~" + paperDelivery.getProductType()));
+    }
+
+    /**
+     * Smista e raggruppa le spedizioni in un unico passaggio sulla lista di input, popolando
+     * {@link SenderLimitJobProcessObjects} con le liste destinate agli step successivi.
+     * <p>
+     * Per ogni {@link PaperDelivery} viene applicata, nell'ordine, la prima regola che corrisponde:
+     * <ol>
+     *     <li>se {@code senderPaId} è assente o vuoto, la spedizione viene aggiunta a
+     *     {@code sendToResidualCapacityStep} (verrà processata nello step EVALUATE_RESIDUAL_CAPACITY
+     *     perché non è possibile valutare un limite mittente senza paId);</li>
+     *     <li>se la comunicazione è INFORMAL, la spedizione viene aggiunta a
+     *     {@code sendToResidualCapacityStep} (le INFORMAL bypassano la valutazione del sender limit);</li>
+     *     <li>se il prodotto è RS oppure si tratta di un secondo tentativo ({@code attempt == 1}),
+     *     la spedizione viene aggiunta a {@code sendToDriverCapacityStep} (va direttamente allo step
+     *     EVALUATE_DRIVER_CAPACITY, senza consumare il sender limit);</li>
+     *     <li>negli altri casi la spedizione viene inserita nella mappa di output, raggruppata per
+     *     chiave {@code senderPaId~productType~province}, mantenendo l'ordine di input all'interno
+     *     di ogni gruppo. Questa mappa è l'input della valutazione del sender limit.</li>
+     * </ol>
+     * Le liste {@code sendToResidualCapacityStep} e {@code sendToDriverCapacityStep} vengono
+     * sostituite (non accodate) sull'oggetto di processo: la chiamata successiva a
+     * {@link #evaluateSenderLimitAndFilterDeliveries(Map, Map, SenderLimitJobProcessObjects)}
+     * provvederà ad aggiungere ulteriori spedizioni a queste stesse liste.
+     * <p>
+     *
+     * @param paperDeliveries lista delle spedizioni arricchite con driver e priorità da smistare
+     * @param senderLimitJobProcessObjects oggetto di processo in cui scrivere le liste destinate
+     *                                     agli step EVALUATE_RESIDUAL_CAPACITY e
+     *                                     EVALUATE_DRIVER_CAPACITY
+     * @return mappa delle spedizioni candidate alla valutazione del sender limit, raggruppate
+     *         per chiave {@code senderPaId~productType~province}
+     */
+    public Map<String, List<PaperDelivery>> classifyAndGroupForSenderLimit(List<PaperDelivery> paperDeliveries, SenderLimitJobProcessObjects senderLimitJobProcessObjects) {
+        List<PaperDelivery> sendToResidualCapacityStep = new ArrayList<>();
+        List<PaperDelivery> sendToDriverCapacityStep = new ArrayList<>();
+        Map<String, List<PaperDelivery>> groupedForSenderLimit = new HashMap<>();
+
+        for (PaperDelivery paperDelivery : paperDeliveries) {
+            if (!StringUtils.hasText(paperDelivery.getSenderPaId())) {
+                sendToResidualCapacityStep.add(paperDelivery);
+            } else if (isInformal(paperDelivery)) {
+                sendToResidualCapacityStep.add(paperDelivery);
+            } else if (isRsOrSecondAttempt(paperDelivery)) {
+                sendToDriverCapacityStep.add(paperDelivery);
+            } else {
+                String key = paperDelivery.getSenderPaId() + "~" + paperDelivery.getProductType() + "~" + paperDelivery.getProvince();
+                groupedForSenderLimit.computeIfAbsent(key, unused -> new ArrayList<>()).add(paperDelivery);
+            }
+        }
+
+        senderLimitJobProcessObjects.setSendToResidualCapacityStep(sendToResidualCapacityStep);
+        senderLimitJobProcessObjects.setSendToDriverCapacityStep(sendToDriverCapacityStep);
+
+        return groupedForSenderLimit;
     }
 
     public Map<String, Long> groupingForExclude(List<PaperDelivery> paperDeliveries) {
@@ -154,41 +197,6 @@ public class PnDelayerUtils {
         senderLimitJobProcessObjects.getSendToDriverCapacityStep().addAll(sendToDriverCapacityStep);
     }
 
-    /**
-     * Filtra e smista le spedizioni in base al prodotto, tentativo e tipo di comunicazione(LEGAL / INFORMAL).
-     * Il metodo esegue separa le spedizioni in INFORMAL e LEGAL.<
-     * Tra le LEGAL Le RS o i secondi tentativi vengono inviati allo step EVALUATE_DRIVER_CAPACITY.
-     * Le restanti vengono restituite come risultato del metodo
-     * Tutte le spedizioni INFORMAL vengono inviate allo step EVALUATE_RESIDUAL_CAPACITY.
-     *
-     * @param items lista delle spedizioni in input
-     * @param senderLimitJobProcessObjects oggetto popolato con le spedizioni suddivise per step di processamento
-     * @return lista delle spedizioni non-INFORMAL che non sono né RS né di secondo tentativo
-     */
-    public List<PaperDelivery> excludeRsAndSecondAttempt(List<PaperDelivery> items, SenderLimitJobProcessObjects senderLimitJobProcessObjects) {
-        var partitionedByCommType = items.stream().collect(Collectors.partitioningBy(this::isInformal));
-        var informalItems = partitionedByCommType.get(true);
-        var legalItems = partitionedByCommType.get(false);
-        var byRsOrSecondAttempt = legalItems.stream().collect(Collectors.partitioningBy(this::isRsOrSecondAttempt));
-        senderLimitJobProcessObjects.setSendToDriverCapacityStep(byRsOrSecondAttempt.get(true));
-        senderLimitJobProcessObjects.getSendToResidualCapacityStep().addAll(informalItems);
-
-        return new ArrayList<>(byRsOrSecondAttempt.get(false));
-    }
-
-    public List<PaperDelivery> excludeEmptyPaId(List<PaperDelivery> paperDeliveries, SenderLimitJobProcessObjects senderLimitJobProcessObjects) {
-        var partitioned = paperDeliveries.stream()
-                .collect(Collectors.partitioningBy(paperDelivery -> StringUtils.hasText(paperDelivery.getSenderPaId())));
-
-        var paperDeliveriesWithPaId = partitioned.get(true);
-        var paperDeliveriesWithoutPaId = partitioned.get(false);
-
-        senderLimitJobProcessObjects.setSendToResidualCapacityStep(
-                new ArrayList<>(paperDeliveriesWithoutPaId)
-        );
-
-        return new ArrayList<>(paperDeliveriesWithPaId);
-    }
 
     private boolean isInformal(PaperDelivery paperDelivery) {
         return CommunicationType.INFORMAL.name().equalsIgnoreCase(paperDelivery.getCommunicationType());

--- a/src/test/java/it/pagopa/pn/delayer/utils/PnDelayerUtilsTest.java
+++ b/src/test/java/it/pagopa/pn/delayer/utils/PnDelayerUtilsTest.java
@@ -64,14 +64,14 @@ class PnDelayerUtilsTest {
     void groupByPaIdProductTypeProvince() {
         List<PaperDelivery> paperDeliveries = new ArrayList<>();
 
-        paperDeliveries.add(createPaperDelivery("AR","00178", "RM", "paId1", 1, 2));
-        paperDeliveries.add(createPaperDelivery("AR","00178", "RM", "paId1", 1, 2));
-        paperDeliveries.add(createPaperDelivery("890","00178", "NA", "paId1", 1, 2));
-        paperDeliveries.add(createPaperDelivery("890","00179", "RM", "paId1", 1, 2));
-        paperDeliveries.add(createPaperDelivery("890","00179", "RM", "paId2", 1, 2));
+        paperDeliveries.add(createPaperDelivery("AR","00178", "RM", "paId1", 0, 2));
+        paperDeliveries.add(createPaperDelivery("AR","00178", "RM", "paId1", 0, 2));
+        paperDeliveries.add(createPaperDelivery("890","00178", "NA", "paId1", 0, 2));
+        paperDeliveries.add(createPaperDelivery("890","00179", "RM", "paId1", 0, 2));
+        paperDeliveries.add(createPaperDelivery("890","00179", "RM", "paId2", 0, 2));
 
 
-        Map<String, List<PaperDelivery>> grouped = pnDelayerUtils.groupByPaIdProductTypeProvince(paperDeliveries);
+        Map<String, List<PaperDelivery>> grouped = pnDelayerUtils.classifyAndGroupForSenderLimit(paperDeliveries, new SenderLimitJobProcessObjects());
         assertEquals(4, grouped.size());
         assertEquals(2, grouped.get("paId1~AR~RM").size());
         assertEquals(1, grouped.get("paId1~890~RM").size());
@@ -79,25 +79,6 @@ class PnDelayerUtilsTest {
         assertEquals(1, grouped.get("paId1~890~NA").size());
     }
 
-
-    @Test
-    void groupByPaIdProductTypeProvinceAndCount() {
-        List<PaperDelivery> paperDeliveries = new ArrayList<>();
-
-        paperDeliveries.add(createPaperDelivery("AR","00178", "RM", "paId1", 1, 2));
-        paperDeliveries.add(createPaperDelivery("AR","00178", "RM", "paId1", 1, 2));
-        paperDeliveries.add(createPaperDelivery("890","00178", "NA", "paId1", 1, 2));
-        paperDeliveries.add(createPaperDelivery("890","00179", "RM", "paId1", 1, 2));
-        paperDeliveries.add(createPaperDelivery("890","00179", "RM", "paId2", 1, 2));
-
-
-        Map<String, Long> grouped = pnDelayerUtils.groupByPaIdProductTypeProvinceAndCount(paperDeliveries);
-        assertEquals(4, grouped.size());
-        assertEquals(2, grouped.get("paId1~AR~RM"));
-        assertEquals(1, grouped.get("paId1~890~RM"));
-        assertEquals(1, grouped.get("paId2~890~RM"));
-        assertEquals(1, grouped.get("paId1~890~NA"));
-    }
 
     @Test
     void groupByGeoKeyAndProduct() {
@@ -130,6 +111,28 @@ class PnDelayerUtilsTest {
         assertEquals(2, grouped.get("00178~AR").size());
         assertEquals(1, grouped.get("00178~890").size());
         assertEquals(2, grouped.get("00179~890").size());
+    }
+
+    @Test
+    void classifyAndGroupForSenderLimit_splitsAndGroupsDeliveriesInSinglePass() {
+        PaperDelivery missingPaId = createPaperDelivery("AR", "00178", "RM", null, 0, 1);
+        PaperDelivery informal = createPaperDelivery("RS", "00179", "RM", "paId1", 0, 1);
+        informal.setCommunicationType("INFORMAL");
+        PaperDelivery rs = createPaperDelivery("RS", "00180", "RM", "paId2", 0, 1);
+        PaperDelivery secondAttempt = createPaperDelivery("AR", "00181", "RM", "paId3", 1, 2);
+        PaperDelivery groupedAr1 = createPaperDelivery("AR", "00182", "RM", "paId4", 0, 3);
+        PaperDelivery groupedAr2 = createPaperDelivery("AR", "00183", "RM", "paId4", 0, 3);
+        PaperDelivery grouped890 = createPaperDelivery("890", "00184", "NA", "paId5", 0, 3);
+        List<PaperDelivery> items = List.of(missingPaId, informal, rs, secondAttempt, groupedAr1, groupedAr2, grouped890);
+        SenderLimitJobProcessObjects senderLimitJobProcessObjects = new SenderLimitJobProcessObjects();
+
+        Map<String, List<PaperDelivery>> grouped = pnDelayerUtils.classifyAndGroupForSenderLimit(items, senderLimitJobProcessObjects);
+
+        assertEquals(List.of(missingPaId, informal), senderLimitJobProcessObjects.getSendToResidualCapacityStep());
+        assertEquals(List.of(rs, secondAttempt), senderLimitJobProcessObjects.getSendToDriverCapacityStep());
+        assertEquals(2, grouped.size());
+        assertEquals(List.of(groupedAr1, groupedAr2), grouped.get("paId4~AR~RM"));
+        assertEquals(List.of(grouped890), grouped.get("paId5~890~NA"));
     }
 
     @Test
@@ -245,9 +248,8 @@ class PnDelayerUtilsTest {
         List<PaperDelivery> items = List.of(paperDelivery1, paperDelivery2, paperDelivery3, paperDelivery4);
         SenderLimitJobProcessObjects senderLimitJobProcessObjects = new SenderLimitJobProcessObjects();
 
-        List<PaperDelivery> result = pnDelayerUtils.excludeRsAndSecondAttempt(items, senderLimitJobProcessObjects);
+        pnDelayerUtils.classifyAndGroupForSenderLimit(items, senderLimitJobProcessObjects);
 
-        assertEquals(0, result.size());
         assertEquals(4, senderLimitJobProcessObjects.getSendToDriverCapacityStep().size());
     }
 
@@ -262,9 +264,8 @@ class PnDelayerUtilsTest {
         List<PaperDelivery> items = List.of(paperDelivery1, paperDelivery2, paperDelivery3, paperDelivery4);
         SenderLimitJobProcessObjects senderLimitJobProcessObjects = new SenderLimitJobProcessObjects();
 
-        List<PaperDelivery> result = pnDelayerUtils.excludeRsAndSecondAttempt(items, senderLimitJobProcessObjects);
+        pnDelayerUtils.classifyAndGroupForSenderLimit(items, senderLimitJobProcessObjects);
 
-        assertEquals(1, result.size());
         assertEquals(1, senderLimitJobProcessObjects.getSendToResidualCapacityStep().size());
         assertEquals(2, senderLimitJobProcessObjects.getSendToDriverCapacityStep().size());
     }
@@ -303,12 +304,8 @@ class PnDelayerUtilsTest {
 
         SenderLimitJobProcessObjects senderLimitJobProcessObjects = new SenderLimitJobProcessObjects();
 
-        List<PaperDelivery> result = pnDelayerUtils.excludeEmptyPaId(paperDeliveries, senderLimitJobProcessObjects);
+        pnDelayerUtils.classifyAndGroupForSenderLimit(paperDeliveries, senderLimitJobProcessObjects);
 
-        assertEquals(2, result.size());
-        assertEquals(3, senderLimitJobProcessObjects.getSendToResidualCapacityStep().size());
-        assertEquals(1, result.stream().filter(d -> "paId1".equals(d.getSenderPaId())).count());
-        assertEquals(1, result.stream().filter(d -> "paId2".equals(d.getSenderPaId())).count());
         assertEquals(1, senderLimitJobProcessObjects.getSendToResidualCapacityStep().stream().filter(d -> d.getSenderPaId() == null).count());
         assertEquals(1, senderLimitJobProcessObjects.getSendToResidualCapacityStep().stream().filter(d -> "".equals(d.getSenderPaId())).count());
         assertEquals(1, senderLimitJobProcessObjects.getSendToResidualCapacityStep().stream().filter(d -> "   ".equals(d.getSenderPaId())).count());
@@ -323,9 +320,8 @@ class PnDelayerUtilsTest {
 
         SenderLimitJobProcessObjects senderLimitJobProcessObjects = new SenderLimitJobProcessObjects();
 
-        List<PaperDelivery> result = pnDelayerUtils.excludeEmptyPaId(paperDeliveries, senderLimitJobProcessObjects);
+        pnDelayerUtils.classifyAndGroupForSenderLimit(paperDeliveries, senderLimitJobProcessObjects);
 
-        assertEquals(2, result.size());
         assertTrue(senderLimitJobProcessObjects.getSendToResidualCapacityStep().isEmpty());
     }
 
@@ -338,9 +334,8 @@ class PnDelayerUtilsTest {
 
         SenderLimitJobProcessObjects senderLimitJobProcessObjects = new SenderLimitJobProcessObjects();
 
-        List<PaperDelivery> result = pnDelayerUtils.excludeEmptyPaId(paperDeliveries, senderLimitJobProcessObjects);
+        pnDelayerUtils.classifyAndGroupForSenderLimit(paperDeliveries, senderLimitJobProcessObjects);
 
-        assertTrue(result.isEmpty());
         assertEquals(3, senderLimitJobProcessObjects.getSendToResidualCapacityStep().size());
     }
 

--- a/src/test/java/it/pagopa/pn/delayer/utils/PnDelayerUtilsTest.java
+++ b/src/test/java/it/pagopa/pn/delayer/utils/PnDelayerUtilsTest.java
@@ -292,6 +292,58 @@ class PnDelayerUtilsTest {
         assertTrue(grouped.isEmpty());
     }
 
+    @Test
+    void excludeEmptyPaId_returnsOnlyDeliveriesWithSenderPaId_andMovesMissingOnesToResidualCapacityStep() {
+        List<PaperDelivery> paperDeliveries = new ArrayList<>();
+        paperDeliveries.add(createPaperDelivery("AR", "00178", "RM", "paId1", 0, 1));
+        paperDeliveries.add(createPaperDelivery("AR", "00179", "RM", "", 0, 1));
+        paperDeliveries.add(createPaperDelivery("RS", "00180", "RM", "   ", 0, 1));
+        paperDeliveries.add(createPaperDelivery("AR", "00181", "RM", null, 0, 1));
+        paperDeliveries.add(createPaperDelivery("890", "00182", "RM", "paId2", 0, 1));
+
+        SenderLimitJobProcessObjects senderLimitJobProcessObjects = new SenderLimitJobProcessObjects();
+
+        List<PaperDelivery> result = pnDelayerUtils.excludeEmptyPaId(paperDeliveries, senderLimitJobProcessObjects);
+
+        assertEquals(2, result.size());
+        assertEquals(3, senderLimitJobProcessObjects.getSendToResidualCapacityStep().size());
+        assertEquals(1, result.stream().filter(d -> "paId1".equals(d.getSenderPaId())).count());
+        assertEquals(1, result.stream().filter(d -> "paId2".equals(d.getSenderPaId())).count());
+        assertEquals(1, senderLimitJobProcessObjects.getSendToResidualCapacityStep().stream().filter(d -> d.getSenderPaId() == null).count());
+        assertEquals(1, senderLimitJobProcessObjects.getSendToResidualCapacityStep().stream().filter(d -> "".equals(d.getSenderPaId())).count());
+        assertEquals(1, senderLimitJobProcessObjects.getSendToResidualCapacityStep().stream().filter(d -> "   ".equals(d.getSenderPaId())).count());
+    }
+
+    @Test
+    void excludeEmptyPaId_whenAllSenderPaIdArePresent_returnsAllAndClearsResidualCapacityStep() {
+        List<PaperDelivery> paperDeliveries = List.of(
+                createPaperDelivery("AR", "00178", "RM", "paId1", 0, 1),
+                createPaperDelivery("890", "00179", "RM", "paId2", 0, 1)
+        );
+
+        SenderLimitJobProcessObjects senderLimitJobProcessObjects = new SenderLimitJobProcessObjects();
+
+        List<PaperDelivery> result = pnDelayerUtils.excludeEmptyPaId(paperDeliveries, senderLimitJobProcessObjects);
+
+        assertEquals(2, result.size());
+        assertTrue(senderLimitJobProcessObjects.getSendToResidualCapacityStep().isEmpty());
+    }
+
+    @Test
+    void excludeEmptyPaId_whenAllSenderPaIdAreMissing_returnsEmptyAndMovesAllToResidualCapacityStep() {
+        List<PaperDelivery> paperDeliveries = new ArrayList<>();
+        paperDeliveries.add(createPaperDelivery("AR", "00178", "RM", null, 0, 1));
+        paperDeliveries.add(createPaperDelivery("890", "00179", "RM", "", 0, 1));
+        paperDeliveries.add(createPaperDelivery("RS", "00180", "RM", "   ", 0, 1));
+
+        SenderLimitJobProcessObjects senderLimitJobProcessObjects = new SenderLimitJobProcessObjects();
+
+        List<PaperDelivery> result = pnDelayerUtils.excludeEmptyPaId(paperDeliveries, senderLimitJobProcessObjects);
+
+        assertTrue(result.isEmpty());
+        assertEquals(3, senderLimitJobProcessObjects.getSendToResidualCapacityStep().size());
+    }
+
     private PaperChannelDeliveryDriver createPaperChannelDeliveryDriver(String geoKey, String product, String driver) {
         PaperChannelDeliveryDriver response = new PaperChannelDeliveryDriver();
         response.setGeoKey(geoKey);
@@ -299,7 +351,6 @@ class PnDelayerUtilsTest {
         response.setUnifiedDeliveryDriver(driver);
         return response;
     }
-
 
     private PaperDelivery createPaperDelivery(String productType, String cap, String province, String senderPaId, Integer attempt, Integer priority) {
         PaperDelivery delivery = new PaperDelivery();


### PR DESCRIPTION
[PN-20082] - Added excludeEmptyPaId method to add empty paId record to residual capacity step

[PN-20082]: https://pagopa.atlassian.net/browse/PN-20082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ