### PR TITLE
Fix: excluded RS and second attempt from counters and setting senderPriority to 0 on paperDelivery table

### DIFF
--- a/functions/kinesisPaperDeliveryLambda/src/app/lib/utils.js
+++ b/functions/kinesisPaperDeliveryLambda/src/app/lib/utils.js
@@ -23,7 +23,7 @@ function buildPaperDeliveryRecord(payload, deliveryWeek, delayed = false, skipSe
     recipientId: payload.recipientId,
     communicationType: payload.communicationType || 'LEGAL',
     workflowStep: 'EVALUATE_SENDER_LIMIT',
-    senderPriority: payload.senderPriority ? payload.senderPriority : 0,
+    senderPriority: rsOrSecondAttempt ? 0 : (payload.senderPriority ? payload.senderPriority : 0),
     deliveryDate: deliveryWeek,
     delayed: Boolean(delayed),
     skipSenderLimit: Boolean(skipSenderLimit)
@@ -92,6 +92,9 @@ function groupRecordsByProductAndProvince(records) {
 
 function groupRecordsBySenderPaId(records) {
   return records.reduce((acc, record) => {
+    if (isRsOrSecondAttempt(record.entity)) {
+      return acc;
+    }
     const key = record.entity.senderPaId;
     if (!key) {
       return acc;

--- a/functions/kinesisPaperDeliveryLambda/src/app/lib/utils.js
+++ b/functions/kinesisPaperDeliveryLambda/src/app/lib/utils.js
@@ -4,6 +4,7 @@ const dayOfWeekEnv = process.env.KINESIS_PAPERDELIVERY_DELIVERYDATEDAYOFWEEK;
 function buildPaperDeliveryRecord(payload, deliveryWeek, delayed = false, skipSenderLimit = false) {
   const rsOrSecondAttempt = isRsOrSecondAttempt(payload);
   const date = rsOrSecondAttempt ? payload.prepareRequestDate : payload.notificationSentAt;
+  const senderPriority = rsOrSecondAttempt || payload.communicationType === 'INFORMAL' ? 0 : payload.senderPriority ?? 0;
 
   const record = {
     pk: buildPk(deliveryWeek),
@@ -23,13 +24,13 @@ function buildPaperDeliveryRecord(payload, deliveryWeek, delayed = false, skipSe
     recipientId: payload.recipientId,
     communicationType: payload.communicationType || 'LEGAL',
     workflowStep: 'EVALUATE_SENDER_LIMIT',
-    senderPriority: rsOrSecondAttempt ? 0 : (payload.senderPriority ? payload.senderPriority : 0),
+    senderPriority: senderPriority,
     deliveryDate: deliveryWeek,
     delayed: Boolean(delayed),
     skipSenderLimit: Boolean(skipSenderLimit)
   };
 
-  if (payload.senderPaId && !rsOrSecondAttempt) {
+  if (payload.senderPaId && !rsOrSecondAttempt && payload.communicationType !== 'INFORMAL') {
     record.senderPaIdOriginalSentAt = `${payload.senderPaId}~${date}`;
   }
 
@@ -92,7 +93,7 @@ function groupRecordsByProductAndProvince(records) {
 
 function groupRecordsBySenderPaId(records) {
   return records.reduce((acc, record) => {
-    if (isRsOrSecondAttempt(record.entity)) {
+    if (!record.entity.senderPaId || isRsOrSecondAttempt(record.entity) || record.entity.communicationType === 'INFORMAL') {
       return acc;
     }
     const key = record.entity.senderPaId;

--- a/functions/kinesisPaperDeliveryLambda/src/test/utils.test.js
+++ b/functions/kinesisPaperDeliveryLambda/src/test/utils.test.js
@@ -13,7 +13,7 @@ const { expect } = require("chai");
 const sinon = require("sinon");
 
 describe('buildPaperDeliveryHighPriorityRecord', () => {
-  it('builds a record with all required fields from payload', () => {
+  it('builds a record with all required fields from payload INFORMAL', () => {
     const payload = {
       recipientNormalizedAddress: { pr: 'province1', cap: '12345', region: 'region1' },
       requestId: 'req1',
@@ -45,15 +45,56 @@ describe('buildPaperDeliveryHighPriorityRecord', () => {
       prepareRequestDate: '2024-01-01T00:00:00Z',
       attempt: 0,
       communicationType: 'INFORMAL',
-      senderPaIdOriginalSentAt: 'sender1~2025-01-01T00:00:00Z',
       deliveryDate: '2025-07-07',
       delayed: false,
       skipSenderLimit: false,
-      senderPriority: 5
+      senderPriority: 0
     });
     expect(result).to.have.property('createdAt');
     expect(new Date(result.createdAt).toString()).to.not.equal('Invalid Date');
   });
+
+  it('builds a record with all required fields from payload LEGAL', () => {
+      const payload = {
+        recipientNormalizedAddress: { pr: 'province1', cap: '12345', region: 'region1' },
+        requestId: 'req1',
+        productType: 'type1',
+        senderPaId: 'sender1',
+        tenderId: 'tender1',
+        notificationSentAt: '2025-01-01T00:00:00Z',
+        prepareRequestDate: '2024-01-01T00:00:00Z',
+        unifiedDeliveryDriver: 'driver1',
+        attempt: 0,
+        iun: 'iun1',
+        communicationType: 'LEGAL',
+        senderPriority: 5
+      };
+      const result = buildPaperDeliveryRecord(payload, '2025-07-07');
+      expect(result).to.include({
+        pk: '2025-07-07~EVALUATE_SENDER_LIMIT',
+        sk: 'province1~2025-01-01T00:00:00Z~req1',
+        recipientId: payload.recipientId,
+        province: 'province1',
+        requestId: 'req1',
+        productType: 'type1',
+        cap: '12345',
+        senderPaId: 'sender1',
+        unifiedDeliveryDriver: 'driver1',
+        tenderId: 'tender1',
+        iun: 'iun1',
+        notificationSentAt: '2025-01-01T00:00:00Z',
+        prepareRequestDate: '2024-01-01T00:00:00Z',
+        senderPaIdOriginalSentAt: 'sender1~2025-01-01T00:00:00Z',
+        attempt: 0,
+        communicationType: 'LEGAL',
+        deliveryDate: '2025-07-07',
+        delayed: false,
+        skipSenderLimit: false,
+        senderPriority: 5
+      });
+      expect(result).to.have.property('createdAt');
+      expect(new Date(result.createdAt).toString()).to.not.equal('Invalid Date');
+    });
 
   it('builds a second attempt record using prepareRequestDate', () => {
     const payload = {

--- a/functions/kinesisPaperDeliveryLambda/src/test/utils.test.js
+++ b/functions/kinesisPaperDeliveryLambda/src/test/utils.test.js
@@ -25,7 +25,8 @@ describe('buildPaperDeliveryHighPriorityRecord', () => {
       unifiedDeliveryDriver: 'driver1',
       attempt: 0,
       iun: 'iun1',
-      communicationType: 'INFORMAL'
+      communicationType: 'INFORMAL',
+      senderPriority: 5
     };
     const result = buildPaperDeliveryRecord(payload, '2025-07-07');
     expect(result).to.include({
@@ -47,7 +48,8 @@ describe('buildPaperDeliveryHighPriorityRecord', () => {
       senderPaIdOriginalSentAt: 'sender1~2025-01-01T00:00:00Z',
       deliveryDate: '2025-07-07',
       delayed: false,
-      skipSenderLimit: false
+      skipSenderLimit: false,
+      senderPriority: 5
     });
     expect(result).to.have.property('createdAt');
     expect(new Date(result.createdAt).toString()).to.not.equal('Invalid Date');
@@ -64,7 +66,8 @@ describe('buildPaperDeliveryHighPriorityRecord', () => {
       prepareRequestDate: '2024-01-01T00:00:00Z',
       unifiedDeliveryDriver: 'driver1',
       attempt: 1,
-      iun: 'iun1'
+      iun: 'iun1',
+      senderPriority: 5
     };
     const result = buildPaperDeliveryRecord(payload, '2025-07-07');
     expect(result).to.include({
@@ -85,7 +88,8 @@ describe('buildPaperDeliveryHighPriorityRecord', () => {
       communicationType: 'LEGAL',
       deliveryDate: '2025-07-07',
       delayed: false,
-      skipSenderLimit: false
+      skipSenderLimit: false,
+      senderPriority: 0
     });
     expect(result).to.have.property('createdAt');
     expect(new Date(result.createdAt).toString()).to.not.equal('Invalid Date');
@@ -105,7 +109,8 @@ describe('buildPaperDeliveryHighPriorityRecord', () => {
       unifiedDeliveryDriver: 'driver1',
       attempt: 0,
       iun: 'iun1',
-      communicationType: 'LEGAL'
+      communicationType: 'LEGAL',
+      senderPriority: 5
     };
     const result = buildPaperDeliveryRecord(payload, '2025-07-07');
     expect(result).to.include({
@@ -126,7 +131,8 @@ describe('buildPaperDeliveryHighPriorityRecord', () => {
       communicationType: 'LEGAL',
       deliveryDate: '2025-07-07',
       delayed: false,
-      skipSenderLimit: false
+      skipSenderLimit: false,
+      senderPriority: 0
     });
     expect(result).to.have.property('createdAt');
     expect(new Date(result.createdAt).toString()).to.not.equal('Invalid Date');
@@ -304,6 +310,45 @@ describe('buildPaperDeliveryHighPriorityRecord', () => {
         const result = groupRecordsBySenderPaId([r1, r2]);
         expect(Object.keys(result)).to.have.lengthOf(1);
         expect(result['sender1']).to.deep.equal([r1]);
+    });
+
+    it('ignores RS and second-attempt records before grouping by senderPaId', () => {
+      const validRecord = {
+        entity: {
+          senderPaId: 'sender1',
+          productType: 'AR',
+          attempt: 0
+        },
+        kinesisSeqNumber: 'seq1'
+      };
+
+      const rsRecord = {
+        entity: {
+          senderPaId: 'sender1',
+          productType: 'RS',
+          attempt: 0
+        },
+        kinesisSeqNumber: 'seq2'
+      };
+
+      const secondAttemptRecord = {
+        entity: {
+          senderPaId: 'sender2',
+          productType: 'AR',
+          attempt: 1
+        },
+        kinesisSeqNumber: 'seq3'
+      };
+
+      const result = groupRecordsBySenderPaId([
+        validRecord,
+        rsRecord,
+        secondAttemptRecord
+      ]);
+
+      expect(result).to.deep.equal({
+        sender1: [validRecord]
+      });
     });
   });
 

--- a/functions/testDelayerLambda/README.md
+++ b/functions/testDelayerLambda/README.md
@@ -8,7 +8,7 @@ La lambda utilizza un dispatcher per supportare più tipi di operazioni utili pe
 
 | Nome                          | Descrizione                                                                                                                                                          | Parametri (`event.parameters`)                                                                                                                                                                                                   |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **IMPORT_DATA**               | Importa un CSV da S3 nella tabella `pn-DelayerPaperDelivery` tramite scritture `BatchWrite`.                                                                         | `["delayerPaperDeliveryTableName", "paperDeliveryCountersTableName", "senderLimitTableName", "filename", "deliveryWeek"]` deliveryWeek opzionale                                                                                                          |
+| **IMPORT_DATA**               | Importa un CSV da S3 nella tabella `pn-DelayerPaperDelivery` tramite scritture `BatchWrite`.                                                                         | `["delayerPaperDeliveryTableName", "paperDeliveryCountersTableName", "senderLimitTableName", "usedSenderLimitTableName", "filename", "deliveryWeek"]` deliveryWeek opzionale                                                     |
 | **DELETE_DATA**               | Cancella i dati generati dal test dalle tabelle dynamo interessate partendo da un CSV presebte su S3 tramite cancellazioni `BatchWrite`.                             | `["delayerPaperDeliveryTableName","deliveryDriverUsedCapacityTableName", "usedSenderLimitTableName", "paperDeliveryCountersTableName","filename", "]` filename opzionale                                                         |
 | **GET_USED_CAPACITY**         | Legge la capacità utilizzata per la combinazione `unifiedDeliveryDriver~geoKey` alla `deliveryDate` indicata, dalla tabella `pn-PaperDeliveryDriverUsedCapacities`.  | `[ "paperDeliveryDriverUsedCapacitiesTableName", unifiedDeliveryDriver", "geoKey", "deliveryDate (ISO‑8601 UTC)" ]`                                                                                                              |
 | **GET_BY_REQUEST_ID**         | Restituisce **tutte** le righe aventi lo stesso `requestId` interrogando la GSI **`requestId-CreatedAt-index`** della tabella `pn-DelayerPaperDelivery`.             | `[ requestId ]`                                                                                                                                                                                                                  |
@@ -31,7 +31,7 @@ La lambda utilizza un dispatcher per supportare più tipi di operazioni utili pe
 ```json
 {
   "operationType": "IMPORT_DATA",
-  "parameters": ["pn-DelayerPaperDelivery", "pn-PaperDeliveryCounters", "pn-PaperDeliverySenderLimit", "example.csv", "2025-10-03"]
+  "parameters": ["pn-DelayerPaperDelivery", "pn-PaperDeliveryCounters", "pn-PaperDeliverySenderLimit", "pn-PaperDeliveryUsedSenderLimit", "example.csv", "2025-10-03"]
 }
 ```
 

--- a/functions/testDelayerLambda/src/app/importData.js
+++ b/functions/testDelayerLambda/src/app/importData.js
@@ -422,7 +422,7 @@ function buildPaperDeliveryRecord(payload, deliveryWeek, delayed = false, skipSe
     recipientId: payload.recipientId,
     workflowStep: 'EVALUATE_SENDER_LIMIT',
     communicationType: payload.communicationType || 'LEGAL',
-    senderPriority: payload.senderPriority ? parseInt(payload.senderPriority, 10) : 0,
+    senderPriority: rsOrSecondAttempt ? 0 : (payload.senderPriority ? parseInt(payload.senderPriority, 10) : 0),
     deliveryDate: deliveryWeek,
     delayed: Boolean(delayed),
     skipSenderLimit: Boolean(skipSenderLimit)
@@ -471,6 +471,9 @@ function groupRecordsByProductAndProvince(records) {
 
 function groupRecordsBySenderPaId(records) {
     return records.reduce((acc, record) => {
+        if (isRsOrSecondAttempt(record)) {
+          return acc;
+        }
         const key = record.senderPaId;
         if (!key) {
           return acc;

--- a/functions/testDelayerLambda/src/app/importData.js
+++ b/functions/testDelayerLambda/src/app/importData.js
@@ -403,6 +403,7 @@ function isUsedSenderLimitConditionFailure(error) {
 function buildPaperDeliveryRecord(payload, deliveryWeek, delayed = false, skipSenderLimit = false) {
   const rsOrSecondAttempt = isRsOrSecondAttempt(payload);
   const date = rsOrSecondAttempt ? payload.prepareRequestDate : payload.notificationSentAt
+  const senderPriority = rsOrSecondAttempt || payload.communicationType === 'INFORMAL' ? 0 : payload.senderPriority ?? 0;
 
   const record = {
     pk: buildPk(deliveryWeek),
@@ -422,13 +423,13 @@ function buildPaperDeliveryRecord(payload, deliveryWeek, delayed = false, skipSe
     recipientId: payload.recipientId,
     workflowStep: 'EVALUATE_SENDER_LIMIT',
     communicationType: payload.communicationType || 'LEGAL',
-    senderPriority: rsOrSecondAttempt ? 0 : (payload.senderPriority ? parseInt(payload.senderPriority, 10) : 0),
+    senderPriority: senderPriority,
     deliveryDate: deliveryWeek,
     delayed: Boolean(delayed),
     skipSenderLimit: Boolean(skipSenderLimit)
   };
 
-  if (payload.senderPaId && !rsOrSecondAttempt) {
+  if (payload.senderPaId && !rsOrSecondAttempt && payload.communicationType !== 'INFORMAL') {
     record.senderPaIdOriginalSentAt = `${payload.senderPaId}~${date}`;
   }
 
@@ -471,7 +472,7 @@ function groupRecordsByProductAndProvince(records) {
 
 function groupRecordsBySenderPaId(records) {
     return records.reduce((acc, record) => {
-        if (isRsOrSecondAttempt(record)) {
+        if (!record.senderPaId || isRsOrSecondAttempt(record) || record.communicationType === 'INFORMAL') {
           return acc;
         }
         const key = record.senderPaId;

--- a/scripts/aws/cfn/microservice-dev-cfg.json
+++ b/scripts/aws/cfn/microservice-dev-cfg.json
@@ -42,6 +42,6 @@
     "DelayerNotificationOrdersReservedConcurrentExecutions": "5",
     "SenderPriorityVCPU": "1",
     "SenderPriorityMemory": "4096",
-    "EnablePriorityResidualFlow": "true"
+    "EnablePriorityResidualFlow": "false"
   }
 }


### PR DESCRIPTION
Fix: excluded RS and second attempt from counters and setting senderPriority to 0 on paperDelivery table